### PR TITLE
Break out each framework into job via a matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run framework integration tests
+name: Integration tests
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run_tests:
-    name: Framework tests
+    name: Frameworks
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,23 @@ jobs:
   run_tests:
     name: Framework tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        framework:
+          - 'go/gorm'
+          - 'haskell/mysql-haskell'
+          - 'haskell/mysql-simple'
+          - 'java/jdbc'
+          - 'java/spring'
+          - 'javascript/sequelize'
+          - 'javascript/typeorm'
+          - 'php/laravel'
+          - 'python/PyMySQL'
+          - 'python/mysqlclient'
+          - 'ruby/rails'
+          - 'rust/mysql'
+          - 'rust/mysql_async'
+          - 'rust/sqlx'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -16,6 +33,7 @@ jobs:
       - name: Print docker info
         run: docker info
 
-      - name: Execute serial tests
-        run: ./test
+      - name: Bring in test helpers
+        run: source lib.sh
 
+      - run: run_tests ${{ matrix['framework'] }}


### PR DESCRIPTION
The goal of this change is twofold - to parallelize builds using a matrix and have framework-level status reporting.

Since the GitHub Checks API provides historical info breaking out tests to each produce a check result should make it easy to track. This is likely more straightforward than relying on some `pushgateway` or a text file in this repo.