### PR TITLE
Add shellcheck and framework_compare jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Linters
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  shellcheck:
+    name: Check out the repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
+  

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up
+        run: apt-get install -y shellcheck
+
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          scandir: '.'
+        run: shellcheck *.sh
+
 
   framework_compare:
     name: Compare test.yml to workflows on disk

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           scandir: '.'
 
   framework_compare:
-    name: Check out the repository
+    name: Compare test.yml to workflows on disk
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,21 @@ on:
 
 jobs:
   shellcheck:
-    name: Check out the repository
+    name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
 
-  
+  framework_compare:
+    name: Check out the repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compare on-disk to test.yml
+        run: ./tools/compare-frameworks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up
-        run: sudo apt-get install -y shellcheck
-
       - name: Run ShellCheck
         run: shellcheck *.sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
 
   framework_compare:
     name: Check out the repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up
-        run: apt-get install -y shellcheck
+        run: sudo apt-get install -y shellcheck
 
       - name: Run ShellCheck
         run: shellcheck *.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - 'php/laravel'
           - 'python/PyMySQL'
           - 'python/mysqlclient'
+          - 'python/sqlalchemy'
           - 'ruby/rails'
           - 'rust/mysql'
           - 'rust/mysql_async'

--- a/lib.sh
+++ b/lib.sh
@@ -22,6 +22,8 @@ function run_test() {
   pushd "frameworks/${language}/${framework}" >/dev/null || return
 
   if [ -e test ]; then
+    # shellcheck disable=SC2065
+    # The redirection here is intentional.
     ./test &>/dev/null
   elif [ -e Dockerfile ]; then
     tag="$(echo "${language}-${framework}-framework-testing:latest" | tr '[:upper:]' '[:lower:]')"

--- a/tools/compare-frameworks
+++ b/tools/compare-frameworks
@@ -13,7 +13,6 @@ def frameworks_on_disk():
 
     return sorted(frameworks)
 
-
 def frameworks_in_workflow():
     with open(".github/workflows/test.yml") as workflow:
          config = yaml.load(workflow, Loader=yaml.SafeLoader)

--- a/tools/compare-frameworks
+++ b/tools/compare-frameworks
@@ -7,9 +7,8 @@ import pathlib
 def frameworks_on_disk():
     frameworks = []
     for framework in glob.glob('frameworks/*/*'):
-        if not None:
-            framework_parts = pathlib.Path(framework).parts[1:]
-            frameworks.append(str(pathlib.Path(*framework_parts)))
+        framework_parts = pathlib.Path(framework).parts[1:]
+        frameworks.append(str(pathlib.Path(*framework_parts)))
 
     return sorted(frameworks)
 

--- a/tools/compare-frameworks
+++ b/tools/compare-frameworks
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import yaml
+import glob
+import pathlib
+
+def frameworks_on_disk():
+    frameworks = []
+    for framework in glob.glob('frameworks/*/*'):
+        if not None:
+            framework_parts = pathlib.Path(framework).parts[1:]
+            frameworks.append(str(pathlib.Path(*framework_parts)))
+
+    return sorted(frameworks)
+
+
+def frameworks_in_workflow():
+    with open(".github/workflows/test.yml") as workflow:
+         config = yaml.load(workflow, Loader=yaml.SafeLoader)
+         configured_frameworks = \
+                config['jobs']['run_tests']['strategy']['matrix']['framework']
+
+    return sorted(configured_frameworks)
+
+on_disk = frameworks_on_disk()
+in_workflow = frameworks_in_workflow()
+
+assert on_disk == in_workflow, "There are missing frameworks in test.yml"


### PR DESCRIPTION
This pull request introduces jobs that run `shellcheck` on relevant scripts and a job to compare frameworks on disk with the ones in the the `test.yml` job.

Closes https://github.com/planetscale/vitess-framework-testing/issues/37.