### PR TITLE
Small change to make `alltests.sh` only output the exit code of each test

### DIFF
--- a/alltests.sh
+++ b/alltests.sh
@@ -2,6 +2,7 @@
 
 source lib.sh
 
+QUIET=1;
 for framework in $(get_frameworks); do
   run_test "${framework}"
 done

--- a/lib.sh
+++ b/lib.sh
@@ -27,8 +27,13 @@ function run_test() {
     ./test &>/dev/null
   elif [ -e Dockerfile ]; then
     tag="$(echo "${language}-${framework}-framework-testing:latest" | tr '[:upper:]' '[:lower:]')"
-    docker build -t "${tag}" .
-    docker run --rm -i -e VT_HOST -e VT_USERNAME -e VT_PASSWORD -e VT_PORT -e VT_DATABASE "${tag}" &>/dev/null
+    if ! [ -z "${QUIET}" ]; then
+      docker build -t "${tag}" . &>/dev/null
+      docker run --rm -i -e VT_HOST -e VT_USERNAME -e VT_PASSWORD -e VT_PORT -e VT_DATABASE "${tag}" &>/dev/null
+    else
+      docker build -t "${tag}" .
+      docker run --rm -i -e VT_HOST -e VT_USERNAME -e VT_PASSWORD -e VT_PORT -e VT_DATABASE "${tag}"
+    fi;
   fi
 
   echo "${language}/${framework}: $?"


### PR DESCRIPTION
This leaves the default behavior set to output everything so we see all the logs in CI