### PR TITLE
Execute validate_environment before running test

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -45,7 +45,7 @@ function run_test() {
 }
 
 function validate_environment() {
-  if ! ensure_environment_variables 'VT_HOST' 'VT_PORT' 'VT_USERNAME' 'VT_PASSWORD' 'VT_DATABASE'; then
+  if [[ -z $VT_HOST || -z $VT_PORT || -z $VT_USERNAME || -z $VT_PASSWORD || -z $VT_DATABASE ]]; then
     echo "Ensure VT_{HOST,PORT,USERNAME,PASSWORD,DATABASE} are set"
     exit 1
   fi

--- a/lib.sh
+++ b/lib.sh
@@ -15,6 +15,8 @@ function show_and_drop_tables() {
 }
 
 function run_test() {
+  validate_environment
+
   local language framework
   language="$(echo "$1" | cut -d'/' -f1)"
   framework="$(echo "$1" | cut -d'/' -f2)"

--- a/lib.sh
+++ b/lib.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-VT_USERNAME=${VT_USERNAME:-"root"}
-VT_PASSWORD=${VT_PASSWORD:-"root"}
-VT_HOST=${VT_HOST:-"127.0.0.1"}
-VT_PORT=${VT_PORT:-"3306"}
-VT_DATABASE=${VT_DATABASE:-"vitess"}
-
 function show_and_drop_tables() {
   tables="$(mysql --host "${VT_HOST}" --port "${VT_PORT}" --user "${VT_USERNAME}" "-p${VT_PASSWORD}" "${VT_DATABASE}" -Ne 'SHOW TABLES' 2>/dev/null | sed 's/^\|$/`/g' | xargs echo | sed 's/ /,/g')";
 
@@ -45,7 +39,7 @@ function run_test() {
 }
 
 function validate_environment() {
-  if [[ -z $VT_HOST || -z $VT_PORT || -z $VT_USERNAME || -z $VT_PASSWORD || -z $VT_DATABASE ]]; then
+  if [[ -z "$VT_HOST" || -z "$VT_PORT" || -z "$VT_USERNAME" || -z "$VT_PASSWORD" || -z "$VT_DATABASE" ]]; then
     echo "Ensure VT_{HOST,PORT,USERNAME,PASSWORD,DATABASE} are set"
     exit 1
   fi


### PR DESCRIPTION
This change is intended to shorten the time before failure occurs when the test environment is unconfigured. If the relevant environment variables aren't set we shouldn't try to run the test. 