### PR TITLE
Run mysqldump framework test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           - 'java/spring'
           - 'javascript/sequelize'
           - 'javascript/typeorm'
+          - 'mysqldump/import'
           - 'php/laravel'
           - 'python/PyMySQL'
           - 'python/mysqlclient'


### PR DESCRIPTION
This adds `mysqldump/import` as a framework in the list of tests. This should get the the linting comparison job passing again.