### PR TITLE
Run each framework against vanilla MySQL 5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,5 +69,6 @@ jobs:
         env:
           VT_USERNAME: root
           VT_PASSWORD: root
+          VT_DATABASE: test
           VT_HOST: 127.0.0.1
           VT_PORT: 33806

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      mysql57:
+        image: mysql:5.7
+        ports:
+          - 33576:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
       mysql8:
-        image: mysql:8.0
+        image: mysql:8
         ports:
           - 33806:3306
         env:
@@ -47,11 +55,19 @@ jobs:
         with:
           submodules: true
     
-      - name: Run test
+      - name: Run tests against upstream MySQL 5.7
         run: source lib.sh && run_test ${{ matrix['framework'] }}
         env:
           VT_USERNAME: root
           VT_PASSWORD: root
           VT_DATABASE: test
+          VT_HOST: 127.0.0.1
+          VT_PORT: 33576
+
+      - name: Run tests against upstream MySQL 8.0
+        run: source lib.sh && run_test ${{ matrix['framework'] }}
+        env:
+          VT_USERNAME: root
+          VT_PASSWORD: root
           VT_HOST: 127.0.0.1
           VT_PORT: 33806

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,6 @@ jobs:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: root
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
-      mysql8:
-        image: mysql:8
-        ports:
-          - 33806:3306
-        env:
-          MYSQL_DATABASE: test
-          MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     strategy:
       fail-fast: false
       matrix:
@@ -63,12 +55,3 @@ jobs:
           VT_DATABASE: test
           VT_HOST: 127.0.0.1
           VT_PORT: 33576
-
-      - name: Run tests against upstream MySQL 8.0
-        run: source lib.sh && run_test ${{ matrix['framework'] }}
-        env:
-          VT_USERNAME: root
-          VT_PASSWORD: root
-          VT_DATABASE: test
-          VT_HOST: 127.0.0.1
-          VT_PORT: 33806


### PR DESCRIPTION
After landing https://github.com/planetscale/vitess-framework-testing/pull/45 I realized that we should run each of the frameworks against 8.0 and 5.7 because of `sha2` changes for password auth in 8. The reason there is that some of the drivers only support `mysql_native_password` so the goal of this change is to get a baseline against 5.7 where that's the default.