### PR TITLE
Remove warning message from cases 003 and 004 in mysqldump/import

### DIFF
--- a/frameworks/mysqldump/import/src/cases/003_extended-inserts.sql
+++ b/frameworks/mysqldump/import/src/cases/003_extended-inserts.sql
@@ -1,4 +1,3 @@
-Warning: World-writable config file '/etc/my.cnf' is ignored
 -- MariaDB dump 10.17  Distrib 10.4.12-MariaDB, for Linux (x86_64)
 --
 -- Host: 127.0.0.1    Database: nextcloud

--- a/frameworks/mysqldump/import/src/cases/004_no-extended-inserts.sql
+++ b/frameworks/mysqldump/import/src/cases/004_no-extended-inserts.sql
@@ -1,4 +1,3 @@
-Warning: World-writable config file '/etc/my.cnf' is ignored
 -- MariaDB dump 10.17  Distrib 10.4.12-MariaDB, for Linux (x86_64)
 --
 -- Host: 127.0.0.1    Database: nextcloud


### PR DESCRIPTION
This gets rid of two warnings that got output into the SQL cases in the `mysqldump/import` framework as part of #42. It should result in the job passing and fixing that item in https://github.com/planetscale/vitess-framework-testing/issues/48.