### PR TITLE
Remove standalone test script from ruby/rails

### DIFF
--- a/frameworks/ruby/rails/src/config/database.yml
+++ b/frameworks/ruby/rails/src/config/database.yml
@@ -5,6 +5,7 @@ default: &default
   username: <%= ENV['VT_USERNAME'] %>
   password: <%= ENV['VT_PASSWORD'] %>
   host: <%= ENV['VT_HOST'] %>
+  port: <%= ENV['VT_PORT'] %>
   variables:
     sql_mode: 'STRICT_ALL_TABLES,NO_AUTO_VALUE_ON_ZERO'
 

--- a/frameworks/ruby/rails/test
+++ b/frameworks/ruby/rails/test
@@ -1,5 +1,0 @@
-#!/bin/sh
-docker build -t vitess/test/ruby/rails .;
-# TODO:  Test running, not just migrations:  bundle exec rails s -p 80 -b 0.0.0.0
-docker run --rm -i -e VT_HOST -e VT_PORT -e VT_USERNAME -e VT_PASSWORD -e VT_DATABASE -p8000:80 vitess/test/ruby/rails;
-


### PR DESCRIPTION
This pull request gets rid of the test script in `ruby/rails` since it's causing some fast-exit behavior that causes that framework to immediately fail in CI. This will fall back to the default behavior which matches the intent here.

The changes here are part of the efforts in https://github.com/planetscale/vitess-framework-testing/issues/48.