### PR TITLE
Run rust/sqlx tests inside container

### DIFF
--- a/frameworks/rust/sqlx/Dockerfile
+++ b/frameworks/rust/sqlx/Dockerfile
@@ -3,6 +3,5 @@ FROM rust
 ADD upstream /src
 WORKDIR /src/examples/mysql/todos
 ARG DATABASE_URL
-RUN cargo build
-ENTRYPOINT ["cargo", "run"]
+ENTRYPOINT ["run"]
 

--- a/frameworks/rust/sqlx/run
+++ b/frameworks/rust/sqlx/run
@@ -7,6 +7,6 @@ DATABASE_URL="mysql://${VT_USERNAME}:${VT_PASSWORD}@${VT_HOST}:${VT_PORT}/${VT_D
 	cat upstream/examples/mysql/todos/migrations/*.sql;
 ) | mysql --host "${VT_HOST}" --port "${VT_PORT}" --user "${VT_USERNAME}" "-p${VT_PASSWORD}" "${VT_DATABASE}" || exit 1;
 
-docker build --build-arg DATABASE_URL="${DATABASE_URL}" -t vitess/test/rust/sqlx .;
-docker run --rm -i -e DATABASE_URL="${DATABASE_URL}" vitess/test/rust/sqlx;
+cargo build
+cargo run
 


### PR DESCRIPTION
This pull request adjusts `rust/sqlx` so tests run entirely inside the container. This should fix the build for https://github.com/planetscale/vitess-framework-testing/issues/48.