### PR TITLE
Replace Cargo.toml to include runtime/TLS feature

### DIFF
--- a/frameworks/rust/sqlx/run
+++ b/frameworks/rust/sqlx/run
@@ -2,6 +2,22 @@
 
 git clone https://github.com/launchbadge/sqlx.git upstream
 
+cat <<EOF > Cargo.toml
+[package]
+name = "sqlx-example-mysql-todos"
+version = "0.1.0"
+edition = "2018"
+workspace = "../../../"
+
+[dependencies]
+anyhow = "1.0"
+async-std = { version = "1.5.0", features = [ "attributes" ] }
+futures = "0.3"
+paw = "1.0"
+sqlx = { path = "../../../", features = [ "mysql", "runtime-async-std-native-tls" ] }
+structopt = { version = "0.3", features = [ "paw" ] }
+EOF
+
 DATABASE_URL="mysql://${VT_USERNAME}:${VT_PASSWORD}@${VT_HOST}:${VT_PORT}/${VT_DATABASE}";
 
 (
@@ -9,6 +25,5 @@ DATABASE_URL="mysql://${VT_USERNAME}:${VT_PASSWORD}@${VT_HOST}:${VT_PORT}/${VT_D
 	cat upstream/examples/mysql/todos/migrations/*.sql;
 ) | mysql --host "${VT_HOST}" --port "${VT_PORT}" --user "${VT_USERNAME}" "-p${VT_PASSWORD}" "${VT_DATABASE}" || exit 1;
 
-cargo build
 cargo run
 

--- a/frameworks/rust/sqlx/run
+++ b/frameworks/rust/sqlx/run
@@ -18,7 +18,7 @@ sqlx = { path = "../../../", features = [ "mysql", "runtime-async-std-native-tls
 structopt = { version = "0.3", features = [ "paw" ] }
 EOF
 
-DATABASE_URL="mysql://${VT_USERNAME}:${VT_PASSWORD}@${VT_HOST}:${VT_PORT}/${VT_DATABASE}";
+export DATABASE_URL="mysql://${VT_USERNAME}:${VT_PASSWORD}@${VT_HOST}:${VT_PORT}/${VT_DATABASE}";
 
 (
 	echo 'DROP TABLE IF EXISTS todos;';


### PR DESCRIPTION
This replaces `Cargo.toml` in full in the example all that's used for `rust/sqlx` to pass an additional feature. Because the feature that needs to get enabled is in a downstream dependency the `--features` flag won't work in this case.