### PR TITLE
Add job that runs tests against PSDB directly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         framework:
           - 'go/gorm'
-          - 'haskell/mysql-haskell'
-          - 'haskell/mysql-simple'
-          - 'haskell/persistent-mysql'
           - 'java/jdbc'
           - 'java/spring'
           - 'javascript/sequelize'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         framework:
           - 'go/gorm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
           - 'javascript/sequelize'
           - 'javascript/typeorm'
           - 'mysqldump/export'
-          - 'mysqldump/import'
           - 'php/laravel'
           - 'python/PyMySQL'
           - 'python/mysqlclient'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,15 @@ jobs:
     name: Frameworks
     runs-on: ubuntu-latest
 
+    services:
+      mysql57:
+        image: mysql:5.7
+        ports:
+          - 33576:3306
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -37,6 +46,15 @@ jobs:
         with:
           submodules: true
     
+      - name: Run tests against upstream MySQL 5.7
+        run: source lib.sh && run_test ${{ matrix['framework'] }}
+        env:
+          VT_USERNAME: root
+          VT_PASSWORD: root
+          VT_DATABASE: test
+          VT_HOST: 127.0.0.1
+          VT_PORT: 33576
+
       - name: Run tests against PSDB
         run: source lib.sh && run_test ${{ matrix['framework'] }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,6 @@ jobs:
     name: Frameworks
     runs-on: ubuntu-latest
 
-    services:
-      mysql57:
-        image: mysql:5.7
-        ports:
-          - 33576:3306
-        env:
-          MYSQL_DATABASE: test
-          MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -46,15 +37,6 @@ jobs:
         with:
           submodules: true
     
-      - name: Run tests against upstream MySQL 5.7
-        run: source lib.sh && run_test ${{ matrix['framework'] }}
-        env:
-          VT_USERNAME: root
-          VT_PASSWORD: root
-          VT_DATABASE: test
-          VT_HOST: 127.0.0.1
-          VT_PORT: 33576
-
       - name: Run tests against PSDB
         run: source lib.sh && run_test ${{ matrix['framework'] }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,15 @@ jobs:
           VT_HOST: 127.0.0.1
           VT_PORT: 33576
 
+      - name: Run tests against PSDB
+        run: source lib.sh && run_test ${{ matrix['framework'] }}
+        env:
+          VT_USERNAME: actions
+          VT_PASSWORD: ${{ secrets.VT_PASSWORD }}
+          VT_DATABASE: itest
+          VT_HOST: ${{ secrets.VT_HOST }}
+          VT_PORT: 3306
+
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@v1


### PR DESCRIPTION
This introduces an additional job for each framework in the test matrix. The goal of this is to run tests against real PSDB instances without creating and tearing down a full cluster.