### PR TITLE
Enable haskell tests again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
       matrix:
         framework:
           - 'go/gorm'
+          - 'haskell/mysql-haskell'
+          - 'haskell/mysql-simple'
+          - 'haskell/persistent-mysql'
           - 'java/jdbc'
           - 'java/spring'
           - 'javascript/sequelize'


### PR DESCRIPTION
The time has come. We can support running these tests again now that there is intermediate caching 🥳 