### PR TITLE
Add Tests for Rails Active Record Query Interface in Sharded mode

### DIFF
--- a/frameworks/ruby/rails6/rails-guide/initialVschemaSetup.sh
+++ b/frameworks/ruby/rails6/rails-guide/initialVschemaSetup.sh
@@ -237,3 +237,16 @@ add_sequence_and_vindex "part5s"
 add_sequence_and_vindex "manufacturers"
 add_binary_md5_vindex "assembly5s_part5s" "part5_id"
 add_binary_md5_vindex "manufacturers_part5s" "part5_id"
+
+# Query Interface
+add_sequence_and_vindex "author5s"
+add_sequence_and_vindex "supplier5s"
+add_binary_md5_vindex "book6s" "author5_id"
+add_sequence_table "book6s"
+add_sequence_and_vindex "customer2s"
+add_binary_md5_vindex "order2s" "customer2_id"
+add_sequence_table "order2s"
+add_binary_md5_vindex "reviews" "customer2_id"
+add_sequence_table "reviews"
+add_binary_md5_vindex "book6s_order2s" "book6_id"
+

--- a/frameworks/ruby/rails6/src/db/migrate/20210222101300_add_query_interface_tables.rb
+++ b/frameworks/ruby/rails6/src/db/migrate/20210222101300_add_query_interface_tables.rb
@@ -11,8 +11,8 @@ class AddQueryInterfaceTables < ActiveRecord::Migration[6.1]
     end
 
     create_table :book6s do |t|
-      t.belongs_to :author5, foreign_key: true
-      t.belongs_to :supplier5, foreign_key: true
+      t.belongs_to :author5
+      t.belongs_to :supplier5
       t.string :title
       t.integer :price
       t.integer :year_published
@@ -34,8 +34,8 @@ class AddQueryInterfaceTables < ActiveRecord::Migration[6.1]
     end
 
     create_table :reviews do |t|
-      t.belongs_to :customer2, foreign_key: true
-      t.belongs_to :book6, foreign_key: true
+      t.belongs_to :customer2
+      t.belongs_to :book6
       t.integer :state
       t.integer :rating
       t.string :review


### PR DESCRIPTION
This PR adds the support to also run the Rails Active Record Query Interface tests with vttestserver with 2 shards.